### PR TITLE
Support for AbortController

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,8 @@
     "Promise": false,
     "ReadableStream": false,
     "Response": false,
-    "Symbol": false
+    "Symbol": false,
+    "AbortController": false
   },
   "parserOptions": {
     "ecmaVersion": 6,

--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ fetchStream('/endpoint')
   .then(chunks => console.dir(chunks))
 ```
 
-`AbortController` is also supported in many environments, allowing you to abort ongoing requests.
-
-This is fully in any environment that supports both ReadableStreams & AbortController directly, and has basic support in most other environments, though you may need [a polyfill](https://www.npmjs.com/package/abortcontroller-polyfill) in your own code to use it. To abort a request:
+`AbortController` is supported [in many environments](https://caniuse.com/#feat=abortcontroller), and allows you to abort ongoing requests. This is fully supported in any environment that supports both ReadableStreams & AbortController directly (e.g. Chrome 66+), and has basic support in most other environments, though you may need [a polyfill](https://www.npmjs.com/package/abortcontroller-polyfill) in your own code to use it. To abort a request:
 
 ```js
 const controller = new AbortController();

--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ fetchStream('/endpoint')
   .then(chunks => console.dir(chunks))
 ```
 
+`AbortController` is also supported in many environments, allowing you to abort ongoing requests.
+
+This is fully in any environment that supports both ReadableStreams & AbortController directly, and has basic support in most other environments, though you may need [a polyfill](https://www.npmjs.com/package/abortcontroller-polyfill) in your own code to use it. To abort a request:
+
+```js
+let controller = new AbortController();
+
+fetchStream('/endpoint', {
+  signal: controller.signal
+}).then(() => {
+  // ...
+});
+
+// To abort the ongoing request:
+controller.abort();
+```
+
 ## Browser Compatibility
 `fetch-readablestream` makes the following assumptions on the environment; legacy browsers will need to provide Polyfills for this functionality:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ fetchStream('/endpoint')
 This is fully in any environment that supports both ReadableStreams & AbortController directly, and has basic support in most other environments, though you may need [a polyfill](https://www.npmjs.com/package/abortcontroller-polyfill) in your own code to use it. To abort a request:
 
 ```js
-let controller = new AbortController();
+const controller = new AbortController();
 
 fetchStream('/endpoint', {
   signal: controller.signal

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "release": "./release.sh ${npm_package_version}"
   },
   "devDependencies": {
+    "abortcontroller-polyfill": "^1.1.9",
     "babel-cli": "^6.11.4",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.13.2",

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -43,7 +43,13 @@ export function makeXhrTransport({ responseType, responseParserFactory }) {
           signal.addEventListener('abort', () => {
             // If we abort later, kill the XHR & reject the promise if possible.
             xhr.abort();
-            reject(new Error('AbortError'));
+            const error = new Error('AbortError');
+
+            if (responseStreamController) {
+              responseStreamController.error(error);
+            }
+
+            reject(error);
           }, { once: true });
         }
       }

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -1,6 +1,6 @@
 import { Headers as HeadersPolyfill } from './polyfill/Headers';
 
-function getAbortError() {
+function createAbortError() {
   // From https://github.com/mo/abortcontroller-polyfill/blob/master/src/abortableFetch.js#L56-L64
 
   try {
@@ -8,7 +8,7 @@ function getAbortError() {
   } catch (err) {
     // IE 11 does not support calling the DOMException constructor, use a
     // regular error object on it instead.
-    let abortError = new Error('Aborted');
+    const abortError = new Error('Aborted');
     abortError.name = 'AbortError';
     return abortError;
   }
@@ -51,16 +51,16 @@ export function makeXhrTransport({ responseType, responseParserFactory }) {
       if (signal) {
         if (signal.aborted) {
           // If already aborted, reject immediately & send nothing.
-          reject(getAbortError());
+          reject(createAbortError());
           return;
         } else {
           signal.addEventListener('abort', () => {
             // If we abort later, kill the XHR & reject the promise if possible.
             xhr.abort();
             if (responseStreamController) {
-              responseStreamController.error(getAbortError());
+              responseStreamController.error(createAbortError());
             }
-            reject(getAbortError());
+            reject(createAbortError());
           }, { once: true });
         }
       }

--- a/test/integ/chunked-request.spec.js
+++ b/test/integ/chunked-request.spec.js
@@ -2,10 +2,19 @@ import { AbortController } from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 
 import fetchStream from '../../src/index';
 import { Headers as HeadersPolyfill } from '../../src/polyfill/Headers';
-import { drainResponse, decodeUnaryJSON } from './util';
+import { drainResponse, decodeUnaryJSON, wait } from './util';
 
 if (!window.Headers) {
   window.Headers = HeadersPolyfill;
+}
+
+function assertClosedByClient() {
+  return fetchStream('/srv?method=last-request-closed')
+    .then(drainResponse)
+    .then(decodeUnaryJSON)
+    .then(result => {
+      expect(result.value).toBe(true, 'response was closed by client');
+    });
 }
 
 // These integration tests run through Karma; check `karma.conf.js` for
@@ -37,16 +46,11 @@ describe('fetch-readablestream', () => {
           return reader.read()
               .then(() => reader.cancel())
         })
-        .then(() => fetchStream('/srv?method=last-request-closed'))
-        .then(drainResponse)
-        .then(decodeUnaryJSON)
-        .then(result => {
-          expect(result.value).toBe(true, 'response was closed by client');
-        })
+        .then(assertClosedByClient)
         .then(done, done);
   });
 
-  it('can abort the response and close the connection', (done) => {
+  it('can abort the response before reading, to close the connection', (done) => {
     const controller = new AbortController();
     return fetchStream('/srv?method=send-chunks', {
       method: 'POST',
@@ -55,14 +59,34 @@ describe('fetch-readablestream', () => {
     })
         .then(() => {
           controller.abort();
+
+          // Wait briefly to make sure the abort reaches the server
+          return wait(50);
         })
-        .then(() => new Promise((resolve) => setTimeout(resolve, 50)))
-        .then(() => fetchStream('/srv?method=last-request-closed'))
-        .then(drainResponse)
-        .then(decodeUnaryJSON)
-        .then(result => {
-          expect(result.value).toBe(true, 'response was closed by client');
+        .then(assertClosedByClient)
+        .then(done, done);
+  });
+
+  it('can abort the response whilst reading, to close the connection', (done) => {
+    const controller = new AbortController();
+    let result;
+
+    return fetchStream('/srv?method=send-chunks', {
+      method: 'POST',
+      body: JSON.stringify([ 'chunk1', 'chunk2', 'chunk3', 'chunk4' ]),
+      signal: controller.signal
+    })
+        .then(response => {
+          // Open a reader and start reading
+          result = drainResponse(response);
+          controller.abort();
+          return result;
         })
+        .then(fail) // should not resolve successfully
+        .catch((error) => {
+          expect(error.message).toBe('AbortError');
+        })
+        .then(assertClosedByClient)
         .then(done, done);
   });
 

--- a/test/integ/util.js
+++ b/test/integ/util.js
@@ -1,3 +1,7 @@
+export function wait(delay) {
+  return new Promise((resolve) => setTimeout(resolve, delay))
+}
+
 export function drainResponse(response) {
   const chunks = [];
   const reader = response.body.getReader();


### PR DESCRIPTION
Fixes #6.

This PR makes requests through this library abortable. The tests should explain the target behaviour pretty clearly I think.

I've got these tests passing locally in Firefox 62 & Chrome 67 - some help testing in more environments would be great!

I'm going to do some downstream integration testing in our usage of this library elsewhere to confirm it works nicely there too, I'll update this once that's done.

I'm not confident that this works in 100% of cases, and it definitely doesn't cover 100% of the spec, so I've left some caveats in the readme. It should cover the vast majority though, will work fine anywhere with full native readable-stream + abortcontroller support (for now just new Chrome) and it shouldn't ever break anything, so it's definitely a significant improvement.