### PR TITLE
[FIX] fix crlf to split response headers correctly

### DIFF
--- a/src/xhr.js
+++ b/src/xhr.js
@@ -124,7 +124,7 @@ function makeResponseUrl(responseUrl, requestUrl) {
 export function parseResposneHeaders(str) {
   const hdrs = makeHeaders();
   if (str) {
-    const pairs = str.split('\u000d\u000a');
+    const pairs = str.split(/\u000d|\u000a|\u000d\u000a/);
     for (let i = 0; i < pairs.length; i++) {
       const p = pairs[i];
       const index = p.indexOf('\u003a\u0020');


### PR DESCRIPTION
OS : Windows 10, IE 11 (v 11.450.190410.0)


Sometimes CRLF of response header string is only '\n' at old browser (in my case, IE11). 

To prevent unhandled exception, add some defense code by changing from "\r\n" to /\r|\n|\r\n/ . 
